### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/bot/osu.py
+++ b/bot/osu.py
@@ -24,8 +24,8 @@ def stats(instring):
     try:
         for player in data:
             op = str('https://a.ppy.sh/' + player['user_id'] + '\nUsername : ' + player['username']
-                     + '\nPerformance Points : ' + "%.2f" % float(player['pp_raw']) + '\nAccuracy : '
-                     + "%.2f" % float(player['accuracy']) + '\nPlaycount : ' + player['playcount']
+                     + '\nPerformance Points : ' + "{0:.2f}".format(float(player['pp_raw'])) + '\nAccuracy : '
+                     + "{0:.2f}".format(float(player['accuracy'])) + '\nPlaycount : ' + player['playcount']
                      + '\nProfile Link : `osu.ppy.sh/u/' + player['user_id'] + '`')
             result = op
         return result
@@ -59,11 +59,11 @@ def top(instring):
             tits = html.title.text
             msg += str(
                     'Beatmap : ' + tits + ' `osu.ppy.sh/b/' + player[
-                        'beatmap_id'] + '`' + '\n Acc : ' + "%.2f" % float(
-                            acc) + ' | ' + 'Rank : ' + player['rank'] + ' | ' + 'PP : ' + player['pp'] + '\n')
+                        'beatmap_id'] + '`' + '\n Acc : ' + "{0:.2f}".format(float(
+                            acc)) + ' | ' + 'Rank : ' + player['rank'] + ' | ' + 'PP : ' + player['pp'] + '\n')
 
-        result = str(msg + '\nThis request took `' + "%.2f" % (
-            time.time() - start_time) + ' seconds` to process.')
+        result = str(msg + '\nThis request took `' + "{0:.2f}".format((
+            time.time() - start_time)) + ' seconds` to process.')
 
         return result
         # NOTE:- if the result is 'string indices must be integers' that means the API key is wrong


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:lapoozza:lapzbot?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:lapoozza:lapzbot?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)