### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/info_extractor.py
+++ b/info_extractor.py
@@ -21,7 +21,7 @@ def info_extract(fpath):
         print('artist:', artist)
 
         filename = str(title + artist)
-        duration = str('%d:%02d:%02d' % (h, m, s))
+        duration = str('{0:d}:{1:02d}:{2:02d}'.format(h, m, s))
 
         return filename, duration
 
@@ -33,7 +33,7 @@ def info_extract(fpath):
         seconds = float(leng)
         m, s = divmod(seconds, 60)
         h, m = divmod(m, 60)
-        duration = str('%d:%02d:%02d' % (h, m, s))
+        duration = str('{0:d}:{1:02d}:{2:02d}'.format(h, m, s))
         return filename, duration
 
 
@@ -49,5 +49,5 @@ def ytinfo_extractor(savepath):
     seconds = float(leng)
     m, s = divmod(seconds, 60)
     h, m = divmod(m, 60)
-    duration = str('%d:%02d:%02d' % (h, m, s))
+    duration = str('{0:d}:{1:02d}:{2:02d}'.format(h, m, s))
     return filename, duration


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:lapoozza:lapzbot?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:lapoozza:lapzbot?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)